### PR TITLE
fix: update PMD XPathRule class path

### DIFF
--- a/custom-pmd-rules.xml
+++ b/custom-pmd-rules.xml
@@ -38,7 +38,7 @@
     <rule name="AvoidLongMethods"
           language="java"
           message="Method is too long. Consider breaking it into smaller methods (max 20 lines)"
-          class="net.sourceforge.pmd.lang.rule.XPathRule">
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
         <description>Methods should be short and focused on a single responsibility</description>
         <priority>3</priority>
         <properties>
@@ -56,7 +56,7 @@
     <rule name="AvoidLongParameterList"
           language="java"
           message="Method has too many parameters. Consider using parameter object or builder pattern"
-          class="net.sourceforge.pmd.lang.rule.XPathRule">
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
         <description>Methods with many parameters are hard to understand and maintain</description>
         <priority>3</priority>
         <properties>
@@ -71,7 +71,7 @@
     <rule name="AvoidDeepNesting"
           language="java"
           message="Avoid deep nesting. Consider extracting methods or using guard clauses"
-          class="net.sourceforge.pmd.lang.rule.XPathRule">
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
         <description>Deep nesting makes code hard to read and understand</description>
         <priority>3</priority>
         <properties>
@@ -87,7 +87,7 @@
     <rule name="EntityShouldHaveId"
           language="java"
           message="Entity should have an ID field annotated with @Id"
-          class="net.sourceforge.pmd.lang.rule.XPathRule">
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
         <description>Domain entities should have identity</description>
         <priority>2</priority>
         <properties>
@@ -105,7 +105,7 @@
     <rule name="ValueObjectShouldBeImmutable"
           language="java"
           message="Value objects should be immutable - no setter methods allowed"
-          class="net.sourceforge.pmd.lang.rule.XPathRule">
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
         <description>Value objects should be immutable for consistency</description>
         <priority>2</priority>
         <properties>
@@ -125,7 +125,7 @@
     <rule name="ServiceShouldNotHaveState"
           language="java"
           message="Service classes should be stateless - avoid non-final instance fields"
-          class="net.sourceforge.pmd.lang.rule.XPathRule">
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
         <description>Services should be stateless to ensure thread safety</description>
         <priority>2</priority>
         <properties>
@@ -147,7 +147,7 @@
     <rule name="RepositoryShouldExtendJpaRepository"
           language="java"
           message="Repository interfaces should extend JpaRepository or CrudRepository"
-          class="net.sourceforge.pmd.lang.rule.XPathRule">
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
         <description>Repositories should follow Spring Data conventions</description>
         <priority>3</priority>
         <properties>
@@ -167,7 +167,7 @@
     <rule name="RestControllerShouldHaveRequestMapping"
           language="java"
           message="RestController should have @RequestMapping at class level"
-          class="net.sourceforge.pmd.lang.rule.XPathRule">
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
         <description>REST controllers should define base path</description>
         <priority>3</priority>
         <properties>
@@ -186,7 +186,7 @@
     <rule name="AvoidHardcodedSecrets"
           language="java"
           message="Avoid hardcoded passwords, keys, or secrets in source code"
-          class="net.sourceforge.pmd.lang.rule.XPathRule">
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
         <description>Secrets should be externalized to configuration</description>
         <priority>1</priority>
         <properties>
@@ -209,7 +209,7 @@
     <rule name="AvoidSelectAllInRepository"
           language="java"
           message="Avoid SELECT * queries. Be explicit about required fields"
-          class="net.sourceforge.pmd.lang.rule.XPathRule">
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
         <description>Select only required fields for better performance</description>
         <priority>3</priority>
         <properties>
@@ -227,7 +227,7 @@
     <rule name="ControllersShouldNotAccessRepositoriesDirectly"
           language="java"
           message="Controllers should not access repositories directly. Use services instead"
-          class="net.sourceforge.pmd.lang.rule.XPathRule">
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
         <description>Controllers should only interact with service layer</description>
         <priority>2</priority>
         <properties>
@@ -246,7 +246,7 @@
     <rule name="ControllerMethodsShouldHaveProperHttpMapping"
           language="java"
           message="Controller methods should have proper HTTP mapping annotations"
-          class="net.sourceforge.pmd.lang.rule.XPathRule">
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
         <description>All public methods in controllers should have HTTP mapping</description>
         <priority>3</priority>
         <properties>
@@ -267,7 +267,7 @@
     <rule name="AvoidExposingEntitiesInControllers"
           language="java"
           message="Avoid exposing JPA entities directly in REST endpoints. Use DTOs instead"
-          class="net.sourceforge.pmd.lang.rule.XPathRule">
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
         <description>Controllers should use DTOs to avoid exposing internal data model</description>
         <priority>2</priority>
         <properties>
@@ -287,7 +287,7 @@
     <rule name="ServiceMethodsShouldBeTransactional"
           language="java"
           message="Service methods that modify data should be annotated with @Transactional"
-          class="net.sourceforge.pmd.lang.rule.XPathRule">
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
         <description>Ensure proper transaction management for data modifications</description>
         <priority>3</priority>
         <properties>
@@ -308,7 +308,7 @@
     <rule name="ApiEndpointsShouldHaveVersioning"
           language="java"
           message="API endpoints should include version information"
-          class="net.sourceforge.pmd.lang.rule.XPathRule">
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
         <description>REST APIs should be versioned for backward compatibility</description>
         <priority>3</priority>
         <properties>
@@ -327,7 +327,7 @@
     <rule name="RequestBodyShouldBeValidated"
           language="java"
           message="@RequestBody parameters should be validated with @Valid"
-          class="net.sourceforge.pmd.lang.rule.XPathRule">
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
         <description>Input validation is essential for security and data integrity</description>
         <priority>2</priority>
         <properties>
@@ -346,7 +346,7 @@
     <rule name="ControllersShouldHaveSecurityAnnotations"
           language="java"
           message="Controller methods should have proper security annotations"
-          class="net.sourceforge.pmd.lang.rule.XPathRule">
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
         <description>Secure endpoints with appropriate access control</description>
         <priority>2</priority>
         <properties>
@@ -367,7 +367,7 @@
     <rule name="AvoidEmptyCatchBlocks"
           language="java"
           message="Empty catch blocks should be avoided or properly documented"
-          class="net.sourceforge.pmd.lang.rule.XPathRule">
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
         <description>Empty catch blocks hide errors and make debugging difficult</description>
         <priority>2</priority>
         <properties>
@@ -383,7 +383,7 @@
     <rule name="ConfigurationClassesShouldNotHaveHardcodedValues"
           language="java"
           message="Configuration classes should use externalized properties"
-          class="net.sourceforge.pmd.lang.rule.XPathRule">
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
         <description>Avoid hardcoded values in configuration for flexibility</description>
         <priority>3</priority>
         <properties>
@@ -406,7 +406,7 @@
     <rule name="TestMethodsShouldFollowNamingConvention"
           language="java"
           message="Test methods should follow 'should_ExpectedBehavior_When_StateUnderTest' naming"
-          class="net.sourceforge.pmd.lang.rule.XPathRule">
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
         <description>Consistent test naming improves readability and understanding</description>
         <priority>3</priority>
         <properties>


### PR DESCRIPTION
## Summary
- replace old net.sourceforge.pmd.lang.rule.XPathRule with net.sourceforge.pmd.lang.rule.xpath.XPathRule in custom PMD rules.

## Testing
- `mvn -q pmd:check` *(fails: Non-resolvable parent POM due to network unavailability)*

------
https://chatgpt.com/codex/tasks/task_e_68a721eb7e5c8326b1a181305c98552c