### PR TITLE
chore: upgrade dependency-check plugin to 12.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,10 +223,11 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>8.4.2</version>
+                <version>12.1.0</version>
                 <configuration>
                     <failBuildOnCVSS>7</failBuildOnCVSS>
                     <format>ALL</format>
+                    <nvdApiKey>${NVD_API_KEY}</nvdApiKey>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
## Summary
- update dependency-check-maven plugin to 12.1.0
- configure plugin to read NVD API key from `NVD_API_KEY`

## Testing
- `mvn verify -DskipTests -Dmaven.test.skip=true` *(fails: Non-resolvable parent POM: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a72edad53483269ae10588c4e05609